### PR TITLE
fix: 空文字列で検索した時のエラーハンドリング

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneFragment.kt
@@ -50,6 +50,8 @@ class OneFragment : Fragment(R.layout.fragment_one) {
 
                     binding.searchInputLayout.isErrorEnabled = false
 
+                    hideKeyboard(editText)
+
                     lifecycleScope.launch {
                         val items = viewModel.searchResults(inputText)
                         adapter.submitList(items)
@@ -71,6 +73,12 @@ class OneFragment : Fragment(R.layout.fragment_one) {
         val action = OneFragmentDirections
             .actionRepositoriesFragmentToRepositoryFragment(item = item)
         findNavController().navigate(action)
+    }
+
+    private fun hideKeyboard(view: View) {
+        val imm = requireContext().getSystemService(android.content.Context.INPUT_METHOD_SERVICE) as? android.view.inputmethod.InputMethodManager
+        imm?.hideSoftInputFromWindow(view.windowToken, 0)
+        view.clearFocus()
     }
 }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneFragment.kt
@@ -38,12 +38,17 @@ class OneFragment : Fragment(R.layout.fragment_one) {
         binding.searchInputText
             .setOnEditorActionListener { editText, action, _ ->
                 if (action == EditorInfo.IME_ACTION_SEARCH) {
-                    editText.text.toString().let {
-                        lifecycleScope.launch {
-                            val items = viewModel.searchResults(it)
-                            adapter.submitList(items)
-                        }
+                    val inputText = editText.text.toString().trim()
+
+                    if (inputText.isEmpty()) {
+                        return@setOnEditorActionListener true
                     }
+
+                    lifecycleScope.launch {
+                        val items = viewModel.searchResults(inputText)
+                        adapter.submitList(items)
+                    }
+
                     return@setOnEditorActionListener true
                 }
                 return@setOnEditorActionListener false

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneFragment.kt
@@ -41,8 +41,14 @@ class OneFragment : Fragment(R.layout.fragment_one) {
                     val inputText = editText.text.toString().trim()
 
                     if (inputText.isEmpty()) {
+                        binding.searchInputLayout.error = getString(R.string.error_empty_search)
+                        binding.searchInputLayout.isErrorEnabled = true
+                        binding.searchInputText.requestFocus()
+
                         return@setOnEditorActionListener true
                     }
+
+                    binding.searchInputLayout.isErrorEnabled = false
 
                     lifecycleScope.launch {
                         val items = viewModel.searchResults(inputText)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/OneFragment.kt
@@ -69,7 +69,7 @@ class OneFragment : Fragment(R.layout.fragment_one) {
         }
     }
 
-    fun goToRepositoryFragment(item: Item) {
+    private fun goToRepositoryFragment(item: Item) {
         val action = OneFragmentDirections
             .actionRepositoriesFragmentToRepositoryFragment(item = item)
         findNavController().navigate(action)

--- a/app/src/main/res/layout/fragment_one.xml
+++ b/app/src/main/res/layout/fragment_one.xml
@@ -9,7 +9,7 @@
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/searchBar"
         android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
+        android:layout_height="wrap_content"
         android:layout_margin="12dp"
         app:cardCornerRadius="12dp"
         app:cardElevation="8dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">Android Engineer CodeCheck</string>
     <string name="searchInputText_hint">GitHub のリポジトリを検索できるよー</string>
+    <string name="error_empty_search">検索キーワードを入力してください</string>
     <string name="written_language">Written in %s</string>
     <string name="stars_count">%1$d stars</string>
     <string name="watchers_count">%1$d watchers</string>


### PR DESCRIPTION
## 変更内容

- 空文字列で検索した時はAPIを呼ばずにエラー文を表示する

![image](https://github.com/user-attachments/assets/04003d04-54d1-4e77-a490-8220c66cb00a)


## 該当するissue

<!-- もしあれば -->

- close #7 
