### PR TITLE
feat: ダークモードを利用可能にする

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/topActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/topActivity.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 import dagger.hilt.android.AndroidEntryPoint
 import jp.co.yumemi.android.code_check.navigation.AppNavHost
+import jp.co.yumemi.android.code_check.ui.theme.AppTheme
 
 @AndroidEntryPoint
 class TopActivity : ComponentActivity() {
@@ -26,7 +27,9 @@ class TopActivity : ComponentActivity() {
                 window.statusBarColor = Color.Transparent.toArgb()
                 WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = true
             }
-            AppNavHost()
+            AppTheme {
+                AppNavHost()
+            }
         }
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/topActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/topActivity.kt
@@ -21,12 +21,6 @@ class TopActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            val view = LocalView.current
-            SideEffect {
-                val window = (view.context as Activity).window
-                window.statusBarColor = Color.Transparent.toArgb()
-                WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = true
-            }
             AppTheme {
                 AppNavHost()
             }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/OneScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/OneScreen.kt
@@ -1,7 +1,6 @@
 package jp.co.yumemi.android.code_check.ui
 
 import android.util.Log
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
@@ -27,7 +26,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
-import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -99,10 +97,10 @@ fun OneScreen(
     ) {
         Text(
             text = stringResource(R.string.app_name),
-            style = LocalTextStyle.current.copy(
+            style = MaterialTheme.typography.headlineSmall.copy(
                 fontWeight = FontWeight.ExtraBold,
-                fontSize = MaterialTheme.typography.headlineSmall.fontSize,
-                textAlign = TextAlign.Center
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onBackground
             ),
             modifier = Modifier
                 .fillMaxWidth()
@@ -115,8 +113,8 @@ fun OneScreen(
             label = {
                 Text(
                     text = stringResource(R.string.searchInputText_hint),
-                    style = LocalTextStyle.current.copy(
-                        fontSize = MaterialTheme.typography.bodySmall.fontSize,
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        color = MaterialTheme.colorScheme.onBackground
                     )
                 )
             },
@@ -128,9 +126,8 @@ fun OneScreen(
                 if (isEmptyInput) {
                     Text(
                         text = stringResource(R.string.error_empty_search),
-                        style = LocalTextStyle.current.copy(
+                        style = MaterialTheme.typography.bodySmall.copy(
                             color = MaterialTheme.colorScheme.error,
-                            fontSize = MaterialTheme.typography.bodySmall.fontSize
                         ),
                     )
                 }
@@ -202,7 +199,6 @@ fun OneScreen(
                             .clickable {
                                 viewModel.onRepositorySelected(item)
                             },
-                        style = LocalTextStyle.current
                     )
                     if (index < items.lastIndex) {
                         HorizontalDivider(

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/OneScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/OneScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -153,7 +152,7 @@ fun OneScreen(
                 }
             ),
             colors = TextFieldDefaults.colors(
-                unfocusedIndicatorColor = Color.LightGray,
+                unfocusedIndicatorColor = MaterialTheme.colorScheme.outline,
             ),
             modifier = Modifier.fillMaxWidth().shadow(40.dp, RoundedCornerShape(16.dp))
         )
@@ -187,7 +186,7 @@ fun OneScreen(
                     )
                     if (index < items.lastIndex) {
                         HorizontalDivider(
-                            color = Color.LightGray,
+                            color = MaterialTheme.colorScheme.outline,
                             thickness = 1.dp
                         )
                     }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/OneScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/OneScreen.kt
@@ -120,7 +120,7 @@ fun OneScreen(
                 Icon(
                     imageVector = Icons.Default.Search,
                     contentDescription = "search icon",
-                    tint = Color.DarkGray
+                    tint = MaterialTheme.colorScheme.onBackground
                 )
             },
             trailingIcon = {
@@ -132,7 +132,7 @@ fun OneScreen(
                         Icon(
                             imageVector = Icons.Default.Clear,
                             contentDescription = "Clear Text",
-                            tint = Color.DarkGray
+                            tint = MaterialTheme.colorScheme.onBackground
                         )
                     }
                 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/OneScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/OneScreen.kt
@@ -113,7 +113,7 @@ fun OneScreen(
             isError = isEmptyInput,
             supportingText = {
                 if (isEmptyInput) {
-                    Text(stringResource(R.string.error_empty_search), color = Color.Red)
+                    Text(stringResource(R.string.error_empty_search), color = MaterialTheme.colorScheme.error)
                 }
             },
             leadingIcon = {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/OneScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/OneScreen.kt
@@ -2,6 +2,7 @@ package jp.co.yumemi.android.code_check.ui
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -160,12 +161,15 @@ fun OneScreen(
         Spacer(modifier = Modifier.weight(0.1f))
 
         if (isLoading) {
-            CircularProgressIndicator(
+            Box(
                 modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .padding(16.dp),
-                color = Color.Blue
-            )
+                    .fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
         } else {
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/OneScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/OneScreen.kt
@@ -90,11 +90,11 @@ fun OneScreen(
     ) {
         Text(
             text = stringResource(R.string.app_name),
-            fontSize = MaterialTheme.typography.titleLarge.fontSize,
-            fontWeight = FontWeight.Bold,
+            fontSize = MaterialTheme.typography.headlineSmall.fontSize,
+            fontWeight = FontWeight.ExtraBold,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(8.dp),
+                .padding(16.dp),
             textAlign = TextAlign.Center,
         )
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/OneScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/OneScreen.kt
@@ -1,5 +1,7 @@
 package jp.co.yumemi.android.code_check.ui
 
+import android.util.Log
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
@@ -24,6 +26,8 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -70,6 +74,11 @@ fun OneScreen(
 
     val focusManager = LocalFocusManager.current
 
+    Log.d("ColorDebug", "LocalContentColor.current: ${LocalContentColor.current}")
+    Log.d("ColorDebug", "MaterialTheme.colorScheme.onSurface: ${MaterialTheme.colorScheme.onSurface}")
+    Log.d("ColorDebug", "MaterialTheme.colorScheme.onBackground: ${MaterialTheme.colorScheme.onBackground}")
+    Log.d("TypographyDebug", "headlineSmall color: ${MaterialTheme.typography.headlineSmall.color}")
+
     LaunchedEffect(Unit) {
         viewModel.navigateToRepositoryFlow.collectLatest { item ->
             navController.currentBackStackEntry?.savedStateHandle?.set("item", item)
@@ -90,12 +99,14 @@ fun OneScreen(
     ) {
         Text(
             text = stringResource(R.string.app_name),
-            fontSize = MaterialTheme.typography.headlineSmall.fontSize,
-            fontWeight = FontWeight.ExtraBold,
+            style = LocalTextStyle.current.copy(
+                fontWeight = FontWeight.ExtraBold,
+                fontSize = MaterialTheme.typography.headlineSmall.fontSize,
+                textAlign = TextAlign.Center
+            ),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),
-            textAlign = TextAlign.Center,
         )
 
         OutlinedTextField(
@@ -104,7 +115,9 @@ fun OneScreen(
             label = {
                 Text(
                     text = stringResource(R.string.searchInputText_hint),
-                    style = MaterialTheme.typography.bodySmall
+                    style = LocalTextStyle.current.copy(
+                        fontSize = MaterialTheme.typography.bodySmall.fontSize,
+                    )
                 )
             },
             shape = RoundedCornerShape(16.dp),
@@ -113,7 +126,13 @@ fun OneScreen(
             isError = isEmptyInput,
             supportingText = {
                 if (isEmptyInput) {
-                    Text(stringResource(R.string.error_empty_search), color = MaterialTheme.colorScheme.error)
+                    Text(
+                        text = stringResource(R.string.error_empty_search),
+                        style = LocalTextStyle.current.copy(
+                            color = MaterialTheme.colorScheme.error,
+                            fontSize = MaterialTheme.typography.bodySmall.fontSize
+                        ),
+                    )
                 }
             },
             leadingIcon = {
@@ -182,7 +201,8 @@ fun OneScreen(
                             .padding(vertical = 16.dp)
                             .clickable {
                                 viewModel.onRepositorySelected(item)
-                            }
+                            },
+                        style = LocalTextStyle.current
                     )
                     if (index < items.lastIndex) {
                         HorizontalDivider(

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/OneScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/OneScreen.kt
@@ -1,6 +1,5 @@
 package jp.co.yumemi.android.code_check.ui
 
-import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
@@ -71,11 +70,6 @@ fun OneScreen(
     val keyboardController = LocalSoftwareKeyboardController.current
 
     val focusManager = LocalFocusManager.current
-
-    Log.d("ColorDebug", "LocalContentColor.current: ${LocalContentColor.current}")
-    Log.d("ColorDebug", "MaterialTheme.colorScheme.onSurface: ${MaterialTheme.colorScheme.onSurface}")
-    Log.d("ColorDebug", "MaterialTheme.colorScheme.onBackground: ${MaterialTheme.colorScheme.onBackground}")
-    Log.d("TypographyDebug", "headlineSmall color: ${MaterialTheme.typography.headlineSmall.color}")
 
     LaunchedEffect(Unit) {
         viewModel.navigateToRepositoryFlow.collectLatest { item ->

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/RepositoryScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/RepositoryScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ColorFilter.Companion.tint
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
@@ -50,6 +51,7 @@ fun RepositoryScreen(
             Icon(
                 painter = painterResource(id = R.drawable.baseline_keyboard_arrow_left_24),
                 contentDescription = "back one screen",
+                tint = MaterialTheme.colorScheme.onBackground
             )
         }
         AsyncImage(

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/RepositoryScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/RepositoryScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.ColorFilter.Companion.tint
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/RepositoryScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/RepositoryScreen.kt
@@ -106,26 +106,27 @@ fun RepositoryScreen(
             Column {
                 Text(
                     text = stringResource(R.string.stars_count, item.stargazersCount),
-                    style = LocalTextStyle.current.copy(
-                        fontSize = MaterialTheme.typography.bodyLarge.fontSize
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        color = MaterialTheme.colorScheme.onBackground,
                     )
+
                 )
                 Text(
                     text = stringResource(R.string.watchers_count, item.watchersCount),
-                    style = LocalTextStyle.current.copy(
-                        fontSize = MaterialTheme.typography.bodyLarge.fontSize
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        color = MaterialTheme.colorScheme.onBackground,
                     )
                 )
                 Text(
                     text = stringResource(R.string.forks_count, item.forksCount),
-                    style = LocalTextStyle.current.copy(
-                        fontSize = MaterialTheme.typography.bodyLarge.fontSize
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        color = MaterialTheme.colorScheme.onBackground,
                     )
                 )
                 Text(
                     text = stringResource(R.string.open_issues_count, item.openIssuesCount),
-                    style = LocalTextStyle.current.copy(
-                        fontSize = MaterialTheme.typography.bodyLarge.fontSize
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        color = MaterialTheme.colorScheme.onBackground,
                     )
                 )
             }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/RepositoryScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/RepositoryScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -65,7 +66,10 @@ fun RepositoryScreen(
 
         Text(
             text = item.name,
-            fontSize = MaterialTheme.typography.headlineMedium.fontSize,
+            style = LocalTextStyle.current.copy(
+                fontSize = MaterialTheme.typography.headlineMedium.fontSize,
+                fontWeight = MaterialTheme.typography.headlineMedium.fontWeight
+            ),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),
@@ -74,7 +78,9 @@ fun RepositoryScreen(
 
         Text(
             text = "Information",
-            fontSize = MaterialTheme.typography.titleLarge.fontSize,
+            style = LocalTextStyle.current.copy(
+                fontSize = MaterialTheme.typography.titleLarge.fontSize
+            ),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
@@ -90,7 +96,9 @@ fun RepositoryScreen(
 
             Text(
                 text = item.language,
-                fontSize = MaterialTheme.typography.bodyLarge.fontSize
+                style = LocalTextStyle.current.copy(
+                    fontSize = MaterialTheme.typography.bodyLarge.fontSize
+                ),
             )
 
             Spacer(modifier = Modifier.weight(1f))
@@ -98,19 +106,27 @@ fun RepositoryScreen(
             Column {
                 Text(
                     text = stringResource(R.string.stars_count, item.stargazersCount),
-                    fontSize = MaterialTheme.typography.bodyLarge.fontSize
+                    style = LocalTextStyle.current.copy(
+                        fontSize = MaterialTheme.typography.bodyLarge.fontSize
+                    )
                 )
                 Text(
                     text = stringResource(R.string.watchers_count, item.watchersCount),
-                    fontSize = MaterialTheme.typography.bodyLarge.fontSize
+                    style = LocalTextStyle.current.copy(
+                        fontSize = MaterialTheme.typography.bodyLarge.fontSize
+                    )
                 )
                 Text(
                     text = stringResource(R.string.forks_count, item.forksCount),
-                    fontSize = MaterialTheme.typography.bodyLarge.fontSize
+                    style = LocalTextStyle.current.copy(
+                        fontSize = MaterialTheme.typography.bodyLarge.fontSize
+                    )
                 )
                 Text(
                     text = stringResource(R.string.open_issues_count, item.openIssuesCount),
-                    fontSize = MaterialTheme.typography.bodyLarge.fontSize
+                    style = LocalTextStyle.current.copy(
+                        fontSize = MaterialTheme.typography.bodyLarge.fontSize
+                    )
                 )
             }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/RepositoryScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/RepositoryScreen.kt
@@ -64,7 +64,7 @@ fun RepositoryScreen(
 
         Text(
             text = item.name,
-            style = MaterialTheme.typography.headlineMedium,
+            fontSize = MaterialTheme.typography.headlineMedium.fontSize,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),
@@ -73,7 +73,7 @@ fun RepositoryScreen(
 
         Text(
             text = "Information",
-            style = MaterialTheme.typography.titleLarge,
+            fontSize = MaterialTheme.typography.titleLarge.fontSize,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
@@ -89,7 +89,7 @@ fun RepositoryScreen(
 
             Text(
                 text = item.language,
-                style = MaterialTheme.typography.bodyLarge
+                fontSize = MaterialTheme.typography.bodyLarge.fontSize
             )
 
             Spacer(modifier = Modifier.weight(1f))
@@ -97,19 +97,19 @@ fun RepositoryScreen(
             Column {
                 Text(
                     text = stringResource(R.string.stars_count, item.stargazersCount),
-                    style = MaterialTheme.typography.bodyLarge
+                    fontSize = MaterialTheme.typography.bodyLarge.fontSize
                 )
                 Text(
                     text = stringResource(R.string.watchers_count, item.watchersCount),
-                    style = MaterialTheme.typography.bodyLarge
+                    fontSize = MaterialTheme.typography.bodyLarge.fontSize
                 )
                 Text(
                     text = stringResource(R.string.forks_count, item.forksCount),
-                    style = MaterialTheme.typography.bodyLarge
+                    fontSize = MaterialTheme.typography.bodyLarge.fontSize
                 )
                 Text(
                     text = stringResource(R.string.open_issues_count, item.openIssuesCount),
-                    style = MaterialTheme.typography.bodyLarge
+                    fontSize = MaterialTheme.typography.bodyLarge.fontSize
                 )
             }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/theme/Color.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/theme/Color.kt
@@ -1,0 +1,12 @@
+package jp.co.yumemi.android.code_check.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val Purple200 = Color(0xFFBB86FC)
+val Purple500 = Color(0xFF6200EE)
+val Teal200 = Color(0xFF03DAC6)
+val DarkBackground = Color(0xFF121212)
+val LightBackground = Color(0xFFFFFFFF)
+val OnPrimaryDark = Color.Black
+val OnPrimaryLight = Color.White
+val OnSecondary = Color.Black

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/theme/Color.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/theme/Color.kt
@@ -2,9 +2,10 @@ package jp.co.yumemi.android.code_check.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple200 = Color(0xFFBB86FC)
-val Purple500 = Color(0xFF6200EE)
-val Teal200 = Color(0xFF03DAC6)
+
+val MdThemeDarkPrimary = Color(0xFFBB86FC)
+val MdThemeLightPrimary = Color(0xFF6200EE)
+val MdThemeSecondary = Color(0xFF03DAC6)
 val DarkBackground = Color(0xFF121212)
 val LightBackground = Color(0xFFFFFFFF)
 val OnPrimaryDark = Color.Black

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/theme/Theme.kt
@@ -50,7 +50,7 @@ fun AppTheme(
     ) {
         CompositionLocalProvider(
             LocalTextStyle provides MaterialTheme.typography.bodyLarge.copy(
-                color = MaterialTheme.colorScheme.onBackground
+                color = colorScheme.onBackground
             )
         ) {
             content()

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/theme/Theme.kt
@@ -1,5 +1,6 @@
 package jp.co.yumemi.android.code_check.ui.theme
 
+import android.app.Activity
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -7,6 +8,11 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 
 private val DarkColorScheme = darkColorScheme(
     primary = Purple200,
@@ -30,6 +36,14 @@ fun AppTheme(
     content: @Composable () -> Unit
 ) {
     val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            window.statusBarColor = Color.Transparent.toArgb()
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+        }
+    }
     MaterialTheme(
         colorScheme = colorScheme,
         typography = androidx.compose.material3.Typography()

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/theme/Theme.kt
@@ -15,16 +15,16 @@ import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Purple200,
-    secondary = Teal200,
+    primary = MdThemeDarkPrimary,
+    secondary = MdThemeSecondary,
     background = DarkBackground,
     onPrimary = OnPrimaryDark,
     onSecondary = OnSecondary
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple500,
-    secondary = Teal200,
+    primary = MdThemeLightPrimary,
+    secondary = MdThemeSecondary,
     background = LightBackground,
     onPrimary = OnPrimaryLight,
     onSecondary = OnSecondary

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/theme/Theme.kt
@@ -1,0 +1,40 @@
+package jp.co.yumemi.android.code_check.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.graphics.Color
+
+private val DarkColorScheme = darkColorScheme(
+    primary = Color.White,
+    background = Color.Black
+)
+
+private val LightColorScheme = lightColorScheme(
+    primary = Color.Black,
+    background = Color.White
+)
+
+@Composable
+fun AppTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = androidx.compose.material3.Typography()
+    ) {
+        CompositionLocalProvider(
+            LocalTextStyle provides MaterialTheme.typography.bodyLarge.copy(
+                color = MaterialTheme.colorScheme.onBackground
+            )
+        ) {
+            content()
+        }
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/theme/Theme.kt
@@ -7,16 +7,21 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.graphics.Color
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Color.White,
-    background = Color.Black
+    primary = Purple200,
+    secondary = Teal200,
+    background = DarkBackground,
+    onPrimary = OnPrimaryDark,
+    onSecondary = OnSecondary
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Color.Black,
-    background = Color.White
+    primary = Purple500,
+    secondary = Teal200,
+    background = LightBackground,
+    onPrimary = OnPrimaryLight,
+    onSecondary = OnSecondary
 )
 
 @Composable


### PR DESCRIPTION
## 変更内容
- ダークモードを利用可能にする
  - `Theme.kt`, `Color.kt`でダークモードも含めて管理

- Material3のデザインで統一する

## 該当するissue

<!-- もしあれば -->

- close #29 
